### PR TITLE
added login_required decorator to borrow view :palm_tree:

### DIFF
--- a/mysite/inventory/views.py
+++ b/mysite/inventory/views.py
@@ -27,6 +27,7 @@ def detail(request, pk):
 
 
 # pk = item_id
+@login_required
 def borrow(request, pk):
     try:
         item = Item.objects.get(pk=request.POST['item'])


### PR DESCRIPTION
now it redirects to the login screen when user clicks the borrow item instead of creating an instance of itemborrowed without the user and showing an error page